### PR TITLE
fix bugs on udev and e2fsck

### DIFF
--- a/pishrink/Dockerfile
+++ b/pishrink/Dockerfile
@@ -1,10 +1,11 @@
-FROM debian:8
+FROM debian:9
 
 RUN apt-get update && apt-get upgrade -y
 RUN apt-get install -y \
     wget \
     parted \
-    sudo
+    sudo \
+    udev
 
 RUN wget https://raw.githubusercontent.com/Drewsif/PiShrink/master/pishrink.sh && \
     chmod +x pishrink.sh && \


### PR DESCRIPTION
In its current state, the pi image shrinker doesn't work because of the following 2 errors.

#### 1st Bug
```bash
/dev/loop0 has unsupported feature(s): metadata_csum
e2fsck: Get a newer version of e2fsck!
```
This one can be fixed in 2 ways: either by updating e2fsck which is a bit too complex for what is does or by going to a more recent image: Stretch. I choose the 2nd one.

#### 2nd Bug
```bash
udevadm: not found
```
This one is trivial: just install the `udev` package.

---

I have tested this on a couple of images and it seems to be working fine for me. 